### PR TITLE
Add patch to enable MySQLi TLS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,8 @@ RUN rm -f .env .env.local
 # Composer (dependencies)
 COPY --from=composer:2.2.6 /usr/bin/composer /usr/local/bin/composer
 RUN composer install --no-dev && composer dumpautoload -o
+COPY patches/mysql_helper_ssl.patch /tmp/
+RUN patch -p1 < /tmp/mysql_helper_ssl.patch
 
 # Writable DB directory (if you ever switch to sqlite)
 RUN mkdir -p app/db && chmod -R 777 app/db

--- a/patches/mysql_helper_ssl.patch
+++ b/patches/mysql_helper_ssl.patch
@@ -1,0 +1,21 @@
+*** Begin Patch
+*** Update File: vendor/munkireport/munkireport-php/app/helpers/mysql_helper.php
+@@
+-    return $link;
++    /* ---------- SSL fix for Azure --------------------------------------- */
++    if (getenv('CONNECTION_SSL_ENABLED') === 'TRUE') {
++        $ca = getenv('MYSQLI_CLIENT_SSL_CA') ?: getenv('CONNECTION_SSL_CA');
++        if ($ca && file_exists($ca)) {
++            mysqli_ssl_set($link, NULL, NULL, $ca, NULL, NULL);
++        }
++        mysqli_options($link, MYSQLI_OPT_SSL_VERIFY_SERVER_CERT, true);
++        $flags = MYSQLI_CLIENT_SSL;
++        @mysqli_real_connect(
++            $link, $host, $username, $password,
++            $database ?: '', $port ?: 3306, NULL, $flags
++        ) or die(mysqli_connect_error());
++    }
++    /* -------------------------------------------------------------------- */
++    return $link;
+ }
+*** End Patch


### PR DESCRIPTION
## Summary
- add SSL patch for `mysql_helper.php` in the upstream dependency
- apply the patch during image build

## Testing
- `phpunit --version` *(fails: command not found)*